### PR TITLE
Update Select solution with label to pass axe-core

### DIFF
--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -6,14 +6,84 @@ import { COLORS } from '../../constants';
 import Icon from '../Icon';
 import VisuallyHidden from '../VisuallyHidden';
 
+const STYLES = {
+  small: {
+    fontSize: 14,
+    iconSize: 16,
+    borderThickness: 1,
+    height: 24,
+  },
+  large: {
+    fontSize: 18,
+    iconSize: 24,
+    borderThickness: 2,
+    height: 36,
+  },
+};
+
 const IconInput = ({
   label,
   icon,
   width = 250,
   size,
-  placeholder,
+  ...delegated
 }) => {
-  return 'TODO';
+  const styles = STYLES[size];
+
+  // TODO: validate size
+
+  return (
+    <Wrapper>
+      <VisuallyHidden>{label}</VisuallyHidden>
+      <IconWrapper style={{ '--size': styles.iconSize + 'px' }}>
+        <Icon id={icon} size={styles.iconSize} />
+      </IconWrapper>
+      <TextInput
+        {...delegated}
+        style={{
+          '--width': width + 'px',
+          '--height': styles.height + 'px',
+          '--border-thickness': styles.borderThickness + 'px',
+          '--font-size': styles.fontSize + 'px',
+        }}
+      />
+    </Wrapper>
+  );
 };
+
+const Wrapper = styled.label`
+  display: block;
+  position: relative;
+  color: ${COLORS.gray700};
+
+  &:hover {
+    color: ${COLORS.black};
+  }
+`;
+
+const IconWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  margin: auto 0;
+  height: var(--size);
+`;
+
+const TextInput = styled.input`
+  width: var(--width);
+  height: var(--height);
+  font-size: var(--font-size);
+  border: none;
+  border-bottom: var(--border-thickness) solid ${COLORS.black};
+  padding-left: var(--height);
+  color: inherit;
+  font-weight: 700;
+  outline-offset: 2px;
+
+  &::placeholder {
+    font-weight: 400;
+    color: ${COLORS.gray500};
+  }
+`;
 
 export default IconInput;

--- a/src/components/IconInput/IconInput.js
+++ b/src/components/IconInput/IconInput.js
@@ -42,9 +42,9 @@ const IconInput = ({
         {...delegated}
         style={{
           '--width': width + 'px',
-          '--height': styles.height + 'px',
+          '--height': styles.height / 16 + 'rem',
           '--border-thickness': styles.borderThickness + 'px',
-          '--font-size': styles.fontSize + 'px',
+          '--font-size': styles.fontSize / 16 + 'rem',
         }}
       />
     </Wrapper>

--- a/src/components/ProgressBar/ProgressBar.js
+++ b/src/components/ProgressBar/ProgressBar.js
@@ -5,8 +5,74 @@ import styled from 'styled-components';
 import { COLORS } from '../../constants';
 import VisuallyHidden from '../VisuallyHidden';
 
-const ProgressBar = ({ value, size }) => {
-  return <strong>{value}</strong>;
+const STYLES = {
+  small: {
+    height: 8,
+    padding: 0,
+    radius: 4,
+  },
+  medium: {
+    height: 12,
+    padding: 0,
+    radius: 4,
+  },
+  large: {
+    height: 16,
+    padding: 4,
+    radius: 8,
+  },
 };
+
+const ProgressBar = ({ value, size }) => {
+  const styles = STYLES[size];
+
+  if (!styles) {
+    throw new Error(`Unknown size passed to ProgressBar: ${size}`);
+  }
+
+  return (
+    <Wrapper
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin="0"
+      aria-valuemax="100"
+      style={{
+        '--padding': styles.padding + 'px',
+        '--radius': styles.radius + 'px',
+      }}
+    >
+      <VisuallyHidden>{value}%</VisuallyHidden>
+      <BarWrapper>
+        <Bar
+          style={{
+            '--width': value + '%',
+            '--height': styles.height + 'px',
+          }}
+        />
+      </BarWrapper>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  background-color: ${COLORS.transparentGray15};
+  box-shadow: inset 0px 2px 4px ${COLORS.transparentGray35};
+  border-radius: var(--radius);
+  padding: var(--padding);
+`;
+
+const BarWrapper = styled.div`
+  border-radius: 4px;
+
+  /* Trim off corners when progress bar is near-full. */
+  overflow: hidden;
+`;
+
+const Bar = styled.div`
+  width: var(--width);
+  height: var(--height);
+  background-color: ${COLORS.primary};
+  border-radius: 4px 0 0 4px;
+`;
 
 export default ProgressBar;

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -9,10 +9,61 @@ const Select = ({ label, value, onChange, children }) => {
   const displayedValue = getDisplayedValue(value, children);
 
   return (
-    <select value={value} onChange={onChange}>
-      {children}
-    </select>
+    <Wrapper>
+      <NativeSelect value={value} onChange={onChange}>
+        {children}
+      </NativeSelect>
+      <PresentationalBit>
+        {displayedValue}
+        <IconWrapper style={{ '--size': 24 + 'px' }}>
+          <Icon id="chevron-down" strokeWidth={1} size={24} />
+        </IconWrapper>
+      </PresentationalBit>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div`
+  position: relative;
+  width: max-content;
+`;
+
+const NativeSelect = styled.select`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+`;
+
+const PresentationalBit = styled.div`
+  color: ${COLORS.gray700};
+  background-color: ${COLORS.transparentGray15};
+  font-size: ${16 / 16}rem;
+  padding: 12px 16px;
+  padding-right: 52px;
+  border-radius: 8px;
+
+  ${NativeSelect}:focus + & {
+    outline: 1px dotted #212121;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
+
+  ${NativeSelect}:hover + & {
+    color: ${COLORS.black};
+  }
+`;
+
+const IconWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 10px;
+  margin: auto;
+  width: var(--size);
+  height: var(--size);
+  pointer-events: none;
+`;
 
 export default Select;

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -35,6 +35,8 @@ const NativeSelect = styled.select`
   width: 100%;
   height: 100%;
   opacity: 0;
+  /* Allow the select to span the full height in Safari */
+  -webkit-appearance: none;
 `;
 
 const PresentationalBit = styled.div`

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -10,7 +10,12 @@ const Select = ({ label, value, onChange, children }) => {
 
   return (
     <Wrapper>
-      <NativeSelect value={value} onChange={onChange}>
+      <VisuallyHidden>
+        <label htmlFor={label}>
+          {label}
+        </label>
+      </VisuallyHidden>
+      <NativeSelect value={value} onChange={onChange} id={label}>
         {children}
       </NativeSelect>
       <PresentationalBit>


### PR DESCRIPTION
Using the Storybook `Accessibility` addon, which executes `axe-core`, one test scenario comes up as failing: `Select element must have an accessible name`

More Info link: https://dequeuniversity.com/rules/axe/4.2/select-name?application=axeAPI

### As Is, Failing
<img width="870" alt="Screen Shot 2022-04-06 at 12 33 02 PM" src="https://user-images.githubusercontent.com/6540117/162045222-3fe3d788-36ed-4fd0-a475-6eaedc4649af.png">

### Proposed Solution, Passing

<img width="477" alt="Screen Shot 2022-04-06 at 12 38 44 PM" src="https://user-images.githubusercontent.com/6540117/162045557-ee8a549c-2d43-408d-8e97-99943848bafd.png">

