### PR TITLE
Extra border-radius

### DIFF
--- a/src/components/ProgressBar/ProgressBar.js
+++ b/src/components/ProgressBar/ProgressBar.js
@@ -72,7 +72,6 @@ const Bar = styled.div`
   width: var(--width);
   height: var(--height);
   background-color: ${COLORS.primary};
-  border-radius: 4px 0 0 4px;
 `;
 
 export default ProgressBar;


### PR DESCRIPTION
I believe `border-radius` in `Bar` is not needed in the final solution because bar's corners are trimmed with `BarWrapper`